### PR TITLE
Download chromedriver over HTTPS

### DIFF
--- a/screenshots/build.gradle
+++ b/screenshots/build.gradle
@@ -41,7 +41,7 @@ task downloadChromeDriver {
         } else if (Os.isFamily(Os.FAMILY_UNIX)) {
             driverOsFilenamePart = Os.isArch("amd64") ? "linux64" : "linux32"
         }
-        FileUtils.copyURLToFile(new URL("http://chromedriver.storage.googleapis.com/${chromeDriverVersion}/chromedriver_${driverOsFilenamePart}.zip"), outputFile)
+        FileUtils.copyURLToFile(new URL("https://chromedriver.storage.googleapis.com/${chromeDriverVersion}/chromedriver_${driverOsFilenamePart}.zip"), outputFile)
     }
 }
 


### PR DESCRIPTION
Anyone who has the chrome driver already downloaded on their local machine should wipe it out.