### PR TITLE
Added more detail to the discussion of runtime classpath normalization.

### DIFF
--- a/contents/concepts.adoc
+++ b/contents/concepts.adoc
@@ -127,7 +127,7 @@ For a runtime classpath it is possible to provide better insights to Gradle whic
 Given that you want to add a file `build-info.properties` to all your produced jar files which contains volatile information about the build, e.g. the timestamp when the build started or some ID to identify the CI job that published the artifact.
 This file is only used for auditing purposes, and has no effect on the outcome of running tests.
 Nonetheless, this file is part of the runtime classpath for the `test` task. Since the file changes on every build invocation, tests cannot be cached effectively.
-To fix this you can ignore `build-info.properties` on any runtime classpath by adding the following configuration to the build script:
+To fix this you can ignore `build-info.properties` on any runtime classpath by adding the following configuration to the build script in the _consuming_ project:
 
 .build.gradle
 [source.multi-language-sample,groovy]
@@ -139,6 +139,8 @@ include::{samplescodedir}/normalization/build.gradle[tags=normalization]
 ----
 include::{samplescodedir}/normalization/build.gradle.kts[tags=normalization]
 ----
+
+If adding such a file to your jar files is something you do for all of the projects in your build, and you want to filter this file for all consumers, you may wrap the configurations described above in an `allprojects {}` or `subprojects {}` block in the root build script.
 
 The effect of this configuration would be that changes to `build-info.properties` would be ignored for both up-to-date checks and task output caching.
 All runtime classpath inputs for all tasks in the project where this configuration has been made will be affected.


### PR DESCRIPTION
This will be synced with a concurrent PR against gradle/gradle.

Signed-off-by: Tony Robalik <tony@gradle.com>

This issue came up in a discussion with a Gradle Enterprise customer. The main area of confusion was _where_ to put the runtime classpath normalization block. I tried to clarify that with a minimal change, but something even more robust might be called for.

We actually have nearly identical documentation in the [userguide](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:configure_input_normalization), and so I will be duplicating this PR (more or less) there. See https://github.com/gradle/gradle/pull/9529

